### PR TITLE
Fix manager behavior when empty data

### DIFF
--- a/src/Location/CacheManager.php
+++ b/src/Location/CacheManager.php
@@ -189,7 +189,7 @@ class CacheManager extends BaseCacheManager
             return \DateTime::createFromFormat('YmdHis', $date);
         }, $keys);
 
-        $lastLocationKey = $this->generateKey(max($cleanedDates), $id);
+        $lastLocationKey = empty($cleanedDates) ? [] : $this->generateKey(max($cleanedDates), $id);
 
         return $this->get($lastLocationKey);
     }
@@ -219,7 +219,11 @@ class CacheManager extends BaseCacheManager
         foreach ($period as $date) {
             $keys[] = $this->generateKey($date, $id);
         }
+        // Should not be empty (beacause zend cache will explode)
         $remainingKeys = $this->getCache()->hasItems($keys);
+
+        // Bypassing the bad implementation of StorageInterface::getItems
+        $items = empty($remainingKeys) ? [] : $this->getCache()->getItems($remainingKeys);
 
         return array_map(
             function ($value) {
@@ -237,7 +241,7 @@ class CacheManager extends BaseCacheManager
                     ]
                 );
             },
-            $this->getCache()->getItems($remainingKeys)
+            $items
         );
     }
 

--- a/tests/unit/Location/LocationCacheManagerTest.php
+++ b/tests/unit/Location/LocationCacheManagerTest.php
@@ -119,6 +119,29 @@ class LocationCacheManagerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($locations, $result);
     }
 
+    public function testReturnEmptyWithNoMatchingLocations()
+    {
+        $from = new DateTime('2017-07-30');
+        $id = '123';
+
+        $cache = $this->getMockBuilder(BlackHole::class)->getMock();
+
+        $cache->method('hasItems')
+              ->willReturn([]);
+
+        $this->instance->setCache($cache);
+        $result = $this->instance->retrieveLocations($id, $from);
+
+        $this->assertInternalType('array', $result);
+        $this->assertEmpty($result);
+
+        $result2 = $this->instance->retrieveLastLocations($id);
+
+        $this->assertInstanceOf(Collection::class, $result2);
+        $this->assertEmpty($result2);
+
+    }
+
     public function testCanRetrieveLocationWithDateInterval()
     {
         $id = '123';


### PR DESCRIPTION
Changes:
Fix behavior of `CacheManager::retrieveLocations` and `CacheManager::retrieveLastLocations` when no data in cache